### PR TITLE
Fucking GRUB.

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -36,7 +36,7 @@ impl FatValue {
     pub const DEFAULT_END_OF_CHAIN: FatValue = FatValue::EndOfChain(0xFF);
 
     /// Checks whether the current FatValue is an EndOfChain.
-    pub fn is_end_of_chain(&self) -> bool {
+    pub fn is_end_of_chain(self) -> bool {
         if let FatValue::EndOfChain(_) = self {
             true
         } else {


### PR DESCRIPTION
GRUB has some weird expectations on what the data should be in the first two reserved clusters. It will refuse our filesystems if they aren't EndOfChain with specific values in the range. Let's fix it.